### PR TITLE
Correctly append extra information to FrontError messages

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -258,8 +258,9 @@ export class Front {
 			}
 
 			// Format this into something useful, if we can.
-			error.message += ` at ${url} with body ${JSON.stringify(body)}`;
-			throw new FrontError(error);
+			const frontError = new FrontError(error);
+			frontError.message += ` at ${url} with body ${JSON.stringify(body)}`;
+			throw frontError;
 		}).asCallback(callback);
 	}
 


### PR DESCRIPTION
Turns out `FrontError` takes the message from
`error.error._error.message`, and not from `error.message`, so there is
some weird magic going on.

We can append the message after the `FrontError` constructor ran to keep
it simple.

Change-type: patch