### PR TITLE
Don't send conversation_id in the body when updating conversations

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -89,7 +89,8 @@ export class Front {
 		listRecent: (callback?: Callback<Conversations>): Promise<Conversations> =>
 			this.httpCall({ method: 'GET', path: 'conversations' }, null, callback),
 		update: (params: ConversationRequest.Update, callback?: Callback<void>): Promise<void> =>
-			this.httpCall({ method: 'PATCH', path: 'conversations/<conversation_id>' }, params, callback),
+			this.httpCall({ method: 'PATCH', path: `conversations/${params.conversation_id}` },
+				_.omit(params, [ 'conversation_id' ]), callback),
 	};
 
 	public inbox = {


### PR DESCRIPTION
Looks like Front doesn't like it anymore:

```
Body did not satisfy requirements at https://api2.frontapp.com/conversations/cnv_1bax6pn with body
{
  "conversation_id": "cnv_1bax6pn",
  "tags": [ "status", "summary" ],
  "status": "assigned"
}
```

Change-type: patch